### PR TITLE
Update fs-ops.html to remove destPath requirement

### DIFF
--- a/fs-ops.html
+++ b/fs-ops.html
@@ -8,7 +8,7 @@
             sourcePathType: {value: "str"},
 	    sourceFilename: {value: "", required: true},
             sourceFilenameType: {value: "msg"},
-            destPath: {value: "", required: true},
+            destPath: {value: "", required: false},
             destPathType: {value: "str"},
             destFilename: {value: "", required: true},
             destFilenameType: {value: "msg"},


### PR DESCRIPTION
Changed destPath requirement from true to false.
The complete path and filename can be entered into destFilename so destPath should not be a requirement.